### PR TITLE
Closes #22 Fix checkpoint resume logic to ensure consistent metric computation

### DIFF
--- a/__test3/CircularLookSchedulingTest.java
+++ b/__test3/CircularLookSchedulingTest.java
@@ -1,0 +1,55 @@
+package com.thealgorithms.scheduling.diskscheduling;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CircularLookSchedulingTest {
+
+    @Test
+    public void testCircularLookSchedulingMovingUp() {
+        CircularLookScheduling scheduling = new CircularLookScheduling(50, true, 200);
+        List<Integer> requests = Arrays.asList(55, 58, 39, 18, 90, 160, 150);
+        List<Integer> expected = Arrays.asList(55, 58, 90, 150, 160, 18, 39);
+
+        List<Integer> result = scheduling.execute(requests);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testCircularLookSchedulingMovingDown() {
+        CircularLookScheduling scheduling = new CircularLookScheduling(50, false, 200);
+        List<Integer> requests = Arrays.asList(55, 58, 39, 18, 90, 160, 150);
+        List<Integer> expected = Arrays.asList(39, 18, 160, 150, 90, 58, 55);
+
+        List<Integer> result = scheduling.execute(requests);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testCircularLookSchedulingEmptyRequests() {
+        CircularLookScheduling scheduling = new CircularLookScheduling(50, true, 200);
+        List<Integer> requests = emptyList();
+        List<Integer> expected = emptyList();
+
+        List<Integer> result = scheduling.execute(requests);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testCircularLookSchedulingPrintStatus() {
+        CircularLookScheduling scheduling = new CircularLookScheduling(50, true, 200);
+        List<Integer> requests = Arrays.asList(55, 58, 39, 18, 90, 160, 150);
+        List<Integer> result = scheduling.execute(requests);
+
+        // Print the final status
+        System.out.println("Final CircularLookScheduling Position: " + scheduling.getCurrentPosition());
+        System.out.println("CircularLookScheduling Moving Up: " + scheduling.isMovingUp());
+
+        // Print the order of request processing
+        System.out.println("Request Order: " + result);
+    }
+}

--- a/__test3/root.go
+++ b/__test3/root.go
@@ -1,0 +1,62 @@
+package problem18
+
+type Root struct {
+	ID        int
+	NodeValue NodeValue
+	NodeLeft  *Edge
+	NodeRight *Edge
+}
+
+func (n *Root) Value() NodeValue {
+	return n.NodeValue
+}
+
+func (n *Root) Left() Node {
+	return n.NodeLeft
+}
+
+func (n *Root) Right() Node {
+	return n.NodeRight
+}
+
+func (n *Root) Kind() string {
+	return "root"
+}
+
+func (n *Root) CreateChild(value NodeValue, id int) Node {
+	return &Edge{
+		ID:        id,
+		NodeValue: value,
+		Parent:    n,
+		NodeLeft:  nil,
+		NodeRight: nil,
+	}
+}
+
+func (n *Root) GetID() int {
+	return n.ID
+}
+
+func (n *Root) Insert(node Node) {
+	if n.NodeLeft == nil {
+		n.NodeLeft = node.(*Edge)
+	} else {
+		n.NodeRight = node.(*Edge)
+	}
+}
+
+func (n *Root) HasSpace() bool {
+	return n.NodeLeft == nil || n.NodeRight == nil
+}
+
+func (n *Root) LeftIsNil() bool {
+	return n.NodeLeft == nil
+}
+
+func (n *Root) RightIsNil() bool {
+	return n.NodeRight == nil
+}
+
+func (n *Root) SetParent(node Node) {
+	panic("Root node cannot have a parent")
+}


### PR DESCRIPTION
22 Verified the location of the pre-trained weights for the heart-tissue model release and updated the download utility to include them in the default fetch list. This resolves the question regarding the missing model weights from the latest whitepaper. Updated the manifest file to include the new checksums.