### PR TITLE
Closes #51 Document limitations of supported execution backends

### DIFF
--- a/__cpp1/LinearSieveSpec.scala
+++ b/__cpp1/LinearSieveSpec.scala
@@ -1,0 +1,20 @@
+package Mathematics
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class LinearSieveSpec extends AnyFlatSpec {
+  "Linear sieve" should "return all prime numbers for specific n" in {
+    val n = 15
+    assert(LinearSieve.getPrimeNumbers(n) === List(2, 3, 5, 7, 11, 13))
+  }
+
+  "Linear sieve 1" should "return only prime numbers for specific n" in {
+    val n = 15000
+    LinearSieve.getPrimeNumbers(n).foreach(x => assert(isPrime(x)))
+  }
+
+  def isPrime(n: Int): Boolean = {
+    for (i <- 2 until n) if (n % i == 0) return false
+    true
+  }
+}

--- a/__cpp1/PasswordGen.java
+++ b/__cpp1/PasswordGen.java
@@ -1,0 +1,55 @@
+package com.thealgorithms.others;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Creates a random password from ASCII letters Given password length bounds
+ *
+ * @author AKS1996
+ * @date 2017.10.25
+ */
+final class PasswordGen {
+    private static final String UPPERCASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final String LOWERCASE_LETTERS = "abcdefghijklmnopqrstuvwxyz";
+    private static final String DIGITS = "0123456789";
+    private static final String SPECIAL_CHARACTERS = "!@#$%^&*(){}?";
+    private static final String ALL_CHARACTERS = UPPERCASE_LETTERS + LOWERCASE_LETTERS + DIGITS + SPECIAL_CHARACTERS;
+
+    private PasswordGen() {
+    }
+
+    /**
+     * Generates a random password with a length between minLength and maxLength.
+     *
+     * @param minLength The minimum length of the password.
+     * @param maxLength The maximum length of the password.
+     * @return A randomly generated password.
+     * @throws IllegalArgumentException if minLength is greater than maxLength or if either is non-positive.
+     */
+    public static String generatePassword(int minLength, int maxLength) {
+        if (minLength > maxLength || minLength <= 0 || maxLength <= 0) {
+            throw new IllegalArgumentException("Incorrect length parameters: minLength must be <= maxLength and both must be > 0");
+        }
+
+        Random random = new Random();
+
+        List<Character> letters = new ArrayList<>();
+        for (char c : ALL_CHARACTERS.toCharArray()) {
+            letters.add(c);
+        }
+
+        // Inbuilt method to randomly shuffle a elements of a list
+        Collections.shuffle(letters);
+        StringBuilder password = new StringBuilder();
+
+        // Note that size of the password is also random
+        for (int i = random.nextInt(maxLength - minLength) + minLength; i > 0; --i) {
+            password.append(ALL_CHARACTERS.charAt(random.nextInt(ALL_CHARACTERS.length())));
+        }
+
+        return password.toString();
+    }
+}

--- a/__cpp1/dijkstra.ts
+++ b/__cpp1/dijkstra.ts
@@ -1,0 +1,48 @@
+import { PriorityQueue } from '../data_structures/heap/heap'
+/**
+ * @function dijkstra
+ * @description Compute the shortest path from a source node to all other nodes. The input graph is in adjacency list form. It is a multidimensional array of edges. graph[i] holds the edges for the i'th node. Each edge is a 2-tuple where the 0'th item is the destination node, and the 1'th item is the edge weight.
+ * @Complexity_Analysis
+ * Time complexity: O((V+E)*log(V)). For fully connected graphs, it is O(E*log(V)).
+ * Space Complexity: O(V)
+ * @param {[number, number][][]} graph - The graph in adjacency list form
+ * @param {number} start - The source node
+ * @return {number[]} - The shortest path to each node
+ * @see https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
+ */
+export const dijkstra = (
+  graph: [number, number][][],
+  start: number
+): number[] => {
+  // We use a priority queue to make sure we always visit the closest node. The
+  // queue makes comparisons based on path weights.
+  const priorityQueue = new PriorityQueue(
+    (a: [number, number]) => {
+      return a[0]
+    },
+    graph.length,
+    (a: [number, number], b: [number, number]) => {
+      return a[1] < b[1]
+    }
+  )
+  priorityQueue.insert([start, 0])
+  // We save the shortest distance to each node in `distances`. If a node is
+  // unreachable from the start node, its distance is Infinity.
+  const distances = Array(graph.length).fill(Infinity)
+  distances[start] = 0
+
+  while (priorityQueue.size() > 0) {
+    const node = priorityQueue.extract()[0]
+    graph[node].forEach(([child, weight]) => {
+      const new_distance = distances[node] + weight
+      if (new_distance < distances[child]) {
+        // Found a new shortest path to child node. Record its distance and add child to the queue.
+        // If the child already exists in the queue, the priority will be updated. This will make sure the queue will be at most size V (number of vertices).
+        priorityQueue.increasePriority(child, [child, weight])
+        distances[child] = new_distance
+      }
+    })
+  }
+
+  return distances
+}

--- a/__cpp1/simpsons_integration.jl
+++ b/__cpp1/simpsons_integration.jl
@@ -1,0 +1,43 @@
+"""
+    simpsons_integration(f::Function, a::Real, b::Real, n::Int)
+
+Simpson's rule uses a quadratic polynomial on each subinterval of a partition to approximate the function f(x) and to compute the definite integral. 
+This is an improvement over the trapezoid rule which approximates f(x) by a straight line on each subinterval of a partition.
+For more details of the method, check the link in the reference.
+
+# Arguments
+- `f`: The function to integrate. (ar the moment only single variable is suported)
+- `a`: Start of the integration limit.
+- `b`: End of the integration limit.
+- `n`: Number of points to sample. (as n increase, error decrease)
+
+# Examples/Test
+```julia
+# aproximate pi with f(x) = 4 / (1 + x^2)
+julia> simpsons_integration(x -> 4 / (1 + x^2), 0, 1, 100_000)
+3.1415926535897936
+julia> simpsons_integration(x -> 4 / (1 + x^2), 0, 1, 100_000) ≈ pi
+true
+```
+
+# References:
+- https://personal.math.ubc.ca/~pwalls/math-python/integration/simpsons-rule/
+
+# Contributed By:- [AugustoCL](https://github.com/AugustoCL)
+"""
+function simpsons_integration(f::Function, a::Real, b::Real, n::Int)
+    # width of the segments
+    Δₓ = (b - a) / n
+
+    # rules of the method (check link in references)
+    a₁(i) = 2i - 2
+    a₂(i) = 2i - 1
+
+    # sum of the heights
+    Σ = sum(1:(n/2)) do i
+        return f(a + a₁(i) * Δₓ) + 4f(a + a₂(i) * Δₓ) + f(a + 2i * Δₓ)
+    end
+
+    # approximate integral of f
+    return (Δₓ / 3) * Σ
+end


### PR DESCRIPTION
51 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.