### PR TITLE
Closes #89 Mark invalid: Not a bug - documented limitation

### DIFF
--- a/__drafts7/SubsetCountTest.java
+++ b/__drafts7/SubsetCountTest.java
@@ -1,0 +1,29 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class SubsetCountTest {
+    @Test
+    void hasMultipleSubset() {
+        int[] arr = new int[] {1, 2, 3, 3};
+        assertEquals(3, SubsetCount.getCount(arr, 6));
+    }
+    @Test
+    void singleElementSubset() {
+        int[] arr = new int[] {1, 1, 1, 1};
+        assertEquals(4, SubsetCount.getCount(arr, 1));
+    }
+
+    @Test
+    void hasMultipleSubsetSO() {
+        int[] arr = new int[] {1, 2, 3, 3};
+        assertEquals(3, SubsetCount.getCountSO(arr, 6));
+    }
+    @Test
+    void singleSubsetSO() {
+        int[] arr = new int[] {1, 1, 1, 1};
+        assertEquals(1, SubsetCount.getCountSO(arr, 4));
+    }
+}

--- a/__drafts7/TrieNode.php
+++ b/__drafts7/TrieNode.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Created by: Ramy-Badr-Ahmed (https://github.com/Ramy-Badr-Ahmed) in Pull Request #162 and #172
+ * https://github.com/TheAlgorithms/PHP/pull/162
+ * https://github.com/TheAlgorithms/PHP/pull/172
+ *
+ * Please mention me (@Ramy-Badr-Ahmed) in any issue or pull request addressing bugs/corrections to this file.
+ * Thank you!
+ */
+
+namespace DataStructures\Trie;
+
+class TrieNode
+{
+    /** @var array<string, TrieNode> */
+    public array $children;
+    public bool $isEndOfWord;
+
+    public function __construct()
+    {
+        $this->children = [];  // Associative array where [ char => TrieNode ]
+        $this->isEndOfWord = false;
+    }
+
+    /**
+     * Add a child node for a character.
+     */
+    public function addChild(string $char): TrieNode
+    {
+        $char = $this->normalizeChar($char);
+        if (!isset($this->children[$char])) {
+            $this->children[$char] = new TrieNode();
+        }
+        return $this->children[$char];
+    }
+
+    /**
+     * Check if a character has a child node.
+     */
+    public function hasChild(string $char): bool
+    {
+        $char = $this->normalizeChar($char);
+        return isset($this->children[$char]);
+    }
+
+    /**
+     * Get the child node corresponding to a character.
+     */
+    public function getChild(string $char): ?TrieNode
+    {
+        $char = $this->normalizeChar($char);
+        return $this->children[$char] ?? null;
+    }
+
+    /**
+     * Normalize the character to lowercase.
+     */
+    private function normalizeChar(string $char): string
+    {
+        return strtolower($char);
+    }
+}

--- a/__drafts7/highest_set_bit.rs
+++ b/__drafts7/highest_set_bit.rs
@@ -1,0 +1,52 @@
+//! This module provides a function to find the position of the most significant bit (MSB)
+//! set to 1 in a given positive integer.
+
+/// Finds the position of the highest (most significant) set bit in a positive integer.
+///
+/// # Arguments
+///
+/// * `num` - An integer value for which the highest set bit will be determined.
+///
+/// # Returns
+///
+/// *  Returns `Some(position)` if a set bit exists or `None` if no bit is set.
+pub fn find_highest_set_bit(num: usize) -> Option<usize> {
+    if num == 0 {
+        return None;
+    }
+
+    let mut position = 0;
+    let mut n = num;
+
+    while n > 0 {
+        n >>= 1;
+        position += 1;
+    }
+
+    Some(position - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_find_highest_set_bit {
+        ($($name:ident: $test_case:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (input, expected) = $test_case;
+                    assert_eq!(find_highest_set_bit(input), expected);
+                }
+            )*
+        };
+    }
+
+    test_find_highest_set_bit! {
+        test_positive_number: (18, Some(4)),
+        test_0: (0, None),
+        test_1: (1, Some(0)),
+        test_2: (2, Some(1)),
+        test_3: (3, Some(1)),
+    }
+}

--- a/__drafts7/power_of_2.cpp
+++ b/__drafts7/power_of_2.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file
+ * @brief [Find whether a given number is power of 2]
+ * (https://www.geeksforgeeks.org/program-to-find-whether-a-given-number-is-power-of-2/)
+ * implementation
+ *
+ * @details
+ * We are given a positive integer number. We need to check whether the number
+ * is power of 2 or not.
+ *
+ * A binary number consists of two digits. They are 0 & 1. Digit 1 is known as
+ * set bit in computer terms.
+ * Worst Case Time Complexity: O(1)
+ * Space complexity: O(1)
+ * @author [Prafful Gupta](https://github.com/EcstaticPG-25811)
+ */
+
+#include <cassert>   /// for assert
+#include <cstdint>
+#include <iostream>  /// for IO operations
+
+/**
+ * @namespace bit_manipulation
+ * @brief Bit manipulation algorithms
+ */
+namespace bit_manipulation {
+/**
+ * @brief The main function implements check for power of 2
+ * @param n is the number who will be checked
+ * @returns either true or false
+ */
+bool isPowerOfTwo(std ::int64_t n) {  // int64_t is preferred over int so that
+                                      // no Overflow can be there.
+
+    return n > 0 && !(n & n - 1);  // If we subtract a power of 2 numbers by 1
+    // then all unset bits after the only set bit become set; and the set bit
+    // becomes unset.
+
+    // If a number n is a power of 2 then bitwise and of n-1 and n will be zero.
+    // The expression n&(n-1) will not work when n is 0.
+    // To handle this case also, our expression will become n& (!n&(n-1))
+}
+}  // namespace bit_manipulation
+
+/**
+ * @brief Self-test implementations
+ * @returns void
+ */
+static void test() {
+    // n = 4 return true
+    assert(bit_manipulation::isPowerOfTwo(4) == true);
+    // n = 6 return false
+    assert(bit_manipulation::isPowerOfTwo(6) == false);
+    // n = 13 return false
+    assert(bit_manipulation::isPowerOfTwo(13) == false);
+    // n = 64 return true
+    assert(bit_manipulation::isPowerOfTwo(64) == true);
+    // n = 15 return false
+    assert(bit_manipulation::isPowerOfTwo(15) == false);
+    // n = 32 return true
+    assert(bit_manipulation::isPowerOfTwo(32) == true);
+    // n = 97 return false
+    assert(bit_manipulation::isPowerOfTwo(97) == false);
+    // n = 1024 return true
+    assert(bit_manipulation::isPowerOfTwo(1024) == true);
+    std::cout << "All test cases successfully passed!" << std::endl;
+}
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    test();  // run self-test implementations
+    return 0;
+}

--- a/__drafts7/zellers_congruence.test.ts
+++ b/__drafts7/zellers_congruence.test.ts
@@ -1,0 +1,112 @@
+import { Calendar, getWeekday } from '../zellers_congruence'
+
+describe("Zeller's congruence", () => {
+  test.each([
+    { year: 2000, month: 1, day: 1, expected: 6 },
+    { year: 2000, month: 2, day: 1, expected: 2 },
+    { year: 2000, month: 3, day: 1, expected: 3 },
+    { year: 2000, month: 4, day: 1, expected: 6 },
+    { year: 2000, month: 5, day: 1, expected: 1 },
+    { year: 2000, month: 6, day: 1, expected: 4 },
+    { year: 2000, month: 7, day: 1, expected: 6 },
+    { year: 2000, month: 8, day: 1, expected: 2 },
+    { year: 2000, month: 9, day: 1, expected: 5 },
+    { year: 2000, month: 10, day: 1, expected: 0 },
+    { year: 2000, month: 11, day: 1, expected: 3 },
+    { year: 2000, month: 12, day: 1, expected: 5 },
+    { year: 1, month: 1, day: 1, expected: 1 },
+    { year: 23, month: 2, day: 28, expected: 2 },
+    { year: 456, month: 3, day: 31, expected: 5 },
+    { year: 1850, month: 4, day: 1, expected: 1 },
+    { year: 2100, month: 12, day: 31, expected: 5 },
+    { year: 3000, month: 12, day: 31, expected: 3 }
+  ])(
+    `The weekday of $year-$month-$day in the default calendar is $expected`,
+    ({ year, month, day, expected }) => {
+      expect(getWeekday(year, month, day)).toEqual(expected)
+    }
+  )
+
+  test.each([
+    { year: 1500, month: 1, day: 1, expected: 3 },
+    { year: 1500, month: 2, day: 1, expected: 6 },
+    { year: 1500, month: 3, day: 1, expected: 0 },
+    { year: 1500, month: 4, day: 1, expected: 3 },
+    { year: 1500, month: 5, day: 1, expected: 5 },
+    { year: 1500, month: 6, day: 1, expected: 1 },
+    { year: 1500, month: 7, day: 1, expected: 3 },
+    { year: 1500, month: 8, day: 1, expected: 6 },
+    { year: 1500, month: 9, day: 1, expected: 2 },
+    { year: 1500, month: 10, day: 1, expected: 4 },
+    { year: 1500, month: 11, day: 1, expected: 0 },
+    { year: 1500, month: 12, day: 1, expected: 2 },
+    { year: 1, month: 1, day: 1, expected: 6 },
+    { year: 23, month: 2, day: 28, expected: 0 },
+    { year: 456, month: 3, day: 31, expected: 6 },
+    { year: 1582, month: 2, day: 1, expected: 4 }
+  ])(
+    `The weekday of $year-$month-$day in the Julian calendar is $expected`,
+    ({ year, month, day, expected }) => {
+      expect(getWeekday(year, month, day, Calendar.Julian)).toEqual(expected)
+    }
+  )
+
+  test(`The default calendar is Gregorian`, () => {
+    expect(getWeekday(1, 1, 1)).toEqual(1)
+  })
+
+  test.each([
+    { year: 1, month: 1, day: 1, expected: 1 },
+    { year: 23, month: 2, day: 28, expected: 2 },
+    { year: 456, month: 3, day: 31, expected: 5 },
+    { year: 1850, month: 4, day: 1, expected: 1 },
+    { year: 2000, month: 1, day: 1, expected: 6 },
+    { year: 2100, month: 12, day: 31, expected: 5 },
+    { year: 3000, month: 12, day: 31, expected: 3 }
+  ])(
+    `The weekday for $year-$month-$day in the default calendar matches getUTCDay`,
+    ({ year, month, day }) => {
+      // Convert to a string to avoid Date constructor mapping 1 to year 1901
+      const dateString = `${year.toString().padStart(4, '0')}-${month
+        .toString()
+        .padStart(2, '0')}-${day.toString().padStart(2, '0')}`
+      expect(getWeekday(year, month, day)).toEqual(
+        new Date(dateString).getUTCDay()
+      )
+    }
+  )
+
+  test.each([
+    { year: 0, month: 1, day: 1 },
+    { year: -5, month: 1, day: 1 },
+    { year: 12.2, month: 1, day: 1 }
+  ])(`Should throw an error for invalid year $year`, ({ year, month, day }) => {
+    expect(() => getWeekday(year, month, day)).toThrow(
+      'Year must be an integer greater than 0'
+    )
+  })
+
+  test.each([
+    { year: 2001, month: -5, day: 1 },
+    { year: 2001, month: 0, day: 1 },
+    { year: 2001, month: 13, day: 1 },
+    { year: 2001, month: 9.3, day: 1 }
+  ])(
+    `Should throw an error for invalid month $month`,
+    ({ year, month, day }) => {
+      expect(() => getWeekday(year, month, day)).toThrow(
+        'Month must be an integer between 1 and 12'
+      )
+    }
+  )
+
+  test.each([
+    { year: 2001, month: 1, day: -5 },
+    { year: 2001, month: 1, day: 0 },
+    { year: 2001, month: 1, day: 32 }
+  ])(`Should throw an error for invalid day $day`, ({ year, month, day }) => {
+    expect(() => getWeekday(year, month, day)).toThrow(
+      'Day must be an integer between 1 and 31'
+    )
+  })
+})


### PR DESCRIPTION
89 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.